### PR TITLE
fix the missing python problem

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,5 @@
 
 - name: Setup awslogs with new config
   listen: "configure awslogs"
-  command: python /tmp/awslogs-agent-setup.py --region eu-central-1 -c /tmp/awslogs.conf --non-interactive
+  command: python3 /tmp/awslogs-agent-setup.py --region eu-central-1 -c /tmp/awslogs.conf --non-interactive
   become: yes


### PR DESCRIPTION
python is not found on the machine:
```
TASK [ansible-aws-cloudwatch-client : Run the awslogs setup command] ***************************************************************************************************************************************************************************************************
fatal: [i-0233ad2ebda58ddb4]: FAILED! => {"changed": false, "cmd": "python /tmp/awslogs-agent-setup.py --region eu-central-1 -c /tmp/awslogs.conf --non-interactive", "msg": "[Errno 2] No such file or directory: b'python'", "rc": 2, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```
We should use either python3 or python2 instead.